### PR TITLE
Add support for Slovak version sk.mall.tv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # plugin.video.mall.tv
 
-Video doplnìk do [kodi](http://www.kodi.tv/) pro pøehrávání videí z internehové televize [mall.tv](https://www.mall.tv/).
+Video doplnìk do [kodi](http://www.kodi.tv/) pro pøehrávání videí z èeské a slovenské internetové televize [mall.tv](https://www.mall.tv/).
 
 Informace o instalaci najdete na stránkách repozitáøe [Kodi CZ/SK](http://kodi-czsk.github.io/repository/).

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.mall.tv"
        name="Mall.TV"
-       version="0.0.8"
+       version="0.0.9"
        provider-name="koudi">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+2019-09-30 [0.0.9]
+  * Force czech version regardless of geolocation
 2019-02-15 [0.0.8]
   * Added possibility to choose format (HLS/MP4) - thx bbaronSVK
 2018-10-30 [0.0.7]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,11 @@
-2019-09-30 [0.0.9]
+2019-10-05 [0.0.9]
   * Added support for slovak version sk.mall.tv
   * Added country select setting
   * Fixed popular category paging
   * Missing popular category replaced by trending videos
   * Renamed categories according to website
+  * Added fanart for shows and categories
+  * Get thumbnails in better quality
 2019-02-15 [0.0.8]
   * Added possibility to choose format (HLS/MP4) - thx bbaronSVK
 2018-10-30 [0.0.7]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 2019-09-30 [0.0.9]
   * Added support for slovak version sk.mall.tv
   * Added country select setting
+  * Fixed popular category paging
+  * Missing popular category replaced by trending videos
+  * Renamed categories according to website
 2019-02-15 [0.0.8]
   * Added possibility to choose format (HLS/MP4) - thx bbaronSVK
 2018-10-30 [0.0.7]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 2019-09-30 [0.0.9]
-  * Force czech version regardless of geolocation
+  * Added support for slovak version sk.mall.tv
+  * Added country select setting
 2019-02-15 [0.0.8]
   * Added possibility to choose format (HLS/MP4) - thx bbaronSVK
 2018-10-30 [0.0.7]

--- a/mall.py
+++ b/mall.py
@@ -8,10 +8,8 @@ class MallApi():
 
     def __init__(self, plugin):
         self.plugin = plugin
-        if self.plugin.get_setting('country') == '0':
-            self.BASE = 'https://www.mall.tv'
-        else:
-            self.BASE = 'https://sk.mall.tv'
+        self.is_cz = self.plugin.get_setting('country') == '0'
+        self.BASE = 'https://www.mall.tv' if self.is_cz else 'https://sk.mall.tv' 
 
     def warn(self, *args, **kwargs):
         self.plugin.log.warning(*args, **kwargs)
@@ -20,7 +18,7 @@ class MallApi():
         return self.plugin.url_for(*args, **kwargs)
 
     def get_page(self, url):
-        r = requests.get(self.BASE + url, cookies=dict(__selectedLanguage= 'cz' if self.plugin.get_setting('country') == '0' else 'sk'))
+        r = requests.get(self.BASE + url, cookies=dict(__selectedLanguage= 'cz' if self.is_cz else 'sk'))
         return BeautifulSoup(r.content, 'html.parser')
 
     def get_categories(self, ):
@@ -110,9 +108,9 @@ class MallApi():
         result = []
 
         if video_type == 'recent':
-            page = self.get_page('/sekce/nejnovejsi?page={0}'.format(page))
+            page = self.get_page('/sekce/nejnovejsi' if self.is_cz else '/sekcia/najnovsie' +'?page={0}'.format(page))
         elif video_type == 'popular':
-            page = self.get_page('/sekce/nejsledovanejsi?page={0}'.format(page))
+            page = self.get_page('/sekce'if self.is_cz else '/sekcia' + '/trending?page={0}'.format(page))
 
         videos = self.extract_videos(page, search_section=(page == 0))
 

--- a/mall.py
+++ b/mall.py
@@ -18,7 +18,8 @@ class MallApi():
         return self.plugin.url_for(*args, **kwargs)
 
     def get_page(self, url):
-        r = requests.get(self.BASE + url)
+        cookies = dict(__selectedLanguage='cz')
+        r = requests.get(self.BASE + url, cookies=cookies)
         return BeautifulSoup(r.content, 'html.parser')
 
     def get_categories(self, ):

--- a/mall.py
+++ b/mall.py
@@ -6,10 +6,12 @@ import re
 
 class MallApi():
 
-    BASE = 'https://www.mall.tv'
-
     def __init__(self, plugin):
         self.plugin = plugin
+        if self.plugin.get_setting('country') == '0':
+            self.BASE = 'https://www.mall.tv'
+        else:
+            self.BASE = 'https://sk.mall.tv'
 
     def warn(self, *args, **kwargs):
         self.plugin.log.warning(*args, **kwargs)
@@ -18,8 +20,7 @@ class MallApi():
         return self.plugin.url_for(*args, **kwargs)
 
     def get_page(self, url):
-        cookies = dict(__selectedLanguage='cz')
-        r = requests.get(self.BASE + url, cookies=cookies)
+        r = requests.get(self.BASE + url, cookies=dict(__selectedLanguage= 'cz' if self.plugin.get_setting('country') == '0' else 'sk'))
         return BeautifulSoup(r.content, 'html.parser')
 
     def get_categories(self, ):

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -15,4 +15,7 @@
 	<string id="30013">Nejsledovanější</string>
 	<string id="30014">Přejít k pořadu</string>
 	<string id="30015">Video formát</string>
+	<string id="30016">Jazyková verze</string>
+	<string id="30017">Česká</string>
+	<string id="30018">Slovenská</string>
 </strings>

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
 	<string id="30001">Kategorie</string>
-	<string id="30002">Seriály</string>
+	<string id="30002">Pořady</string>
 	<string id="30003">Video</string>
 	<string id="30004">Max. kvalita</string>
 	<string id="30005">1080</string>
@@ -9,10 +9,10 @@
 	<string id="30007">480</string>
 	<string id="30008">360</string>
 	<string id="30009">240</string>
-	<string id="30010">Nejnovější</string>
+	<string id="30010">Nejnovější videa</string>
 	<string id="30011">Další strana</string>
 	<string id="30012">Předchozí strana</string>
-	<string id="30013">Nejsledovanější</string>
+	<string id="30013">Ostatní právě sledují</string>
 	<string id="30014">Přejít k pořadu</string>
 	<string id="30015">Video formát</string>
 	<string id="30016">Jazyková verze</string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -15,4 +15,7 @@
 	<string id="30013">Popular</string>
 	<string id="30014">Go to show</string>
 	<string id="30015">Video format</string>
+	<string id="30016">Language version</string>
+	<string id="30017">Czech</string>
+	<string id="30018">Slovak</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -9,10 +9,10 @@
 	<string id="30007">480</string>
 	<string id="30008">360</string>
 	<string id="30009">240</string>
-	<string id="30010">Recent</string>
+	<string id="30010">Recent videos</string>
 	<string id="30011">Next page</string>
 	<string id="30012">Previous page</string>
-	<string id="30013">Popular</string>
+	<string id="30013">Trending videos</string>
 	<string id="30014">Go to show</string>
 	<string id="30015">Video format</string>
 	<string id="30016">Language version</string>

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
 	<string id="30001">Kategórie</string>
-	<string id="30002">Seriály</string>
+	<string id="30002">Relácie</string>
 	<string id="30003">Video</string>
 	<string id="30004">Max. kvalita</string>
 	<string id="30005">1080</string>
@@ -9,10 +9,10 @@
 	<string id="30007">480</string>
 	<string id="30008">360</string>
 	<string id="30009">240</string>
-	<string id="30010">Najnovšie</string>
+	<string id="30010">Najnovšie videá</string>
 	<string id="30011">Ďalšia strana</string>
 	<string id="30012">Predchádzajúca strana</string>
-	<string id="30013">Nejsledovanejšie</string>
+	<string id="30013">Ostatní práve sledujú</string>
 	<string id="30014">Prejsť k relácii</string>
 	<string id="30015">Video formát</string>
 	<string id="30016">Jazyková verzia</string>

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -15,4 +15,7 @@
 	<string id="30013">Nejsledovanejšie</string>
 	<string id="30014">Prejsť k relácii</string>
 	<string id="30015">Video formát</string>
+	<string id="30016">Jazyková verzia</string>
+	<string id="30017">Česká</string>
+	<string id="30018">Slovenská</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,4 +2,5 @@
     <setting type="lsep" label="30003" />
     <setting label="30004" id="max_quality" type="labelenum" lvalues="30009|30008|30007|30006|30005" default="1080" />
     <setting label="30015" id="format" type="labelenum" values="HLS|MP4" default="HLS"/>
+    <setting label="30016" id="country" type="enum" lvalues="30017|30018" default="0"/>
 </settings>


### PR DESCRIPTION
Po zavedeni slovenskej verzie je pristup na mall.tv zo Slovenska presmerovany na sk.mall.tv. Uprava cez cookie vynuti pouzivanie (povodnej) ceskej verzie.

Ciastocne riesi  #6.