### PR TITLE
Video url extracted from internal json structure instead of using meta data tag, which is no longer working for live videos

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.mall.tv"
        name="Mall.TV"
-       version="0.0.13"
+       version="0.0.14"
        provider-name="koudi">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+2020-10-29 [0.0.14]
+  * Fixed live video stream playback
 2020-10-14 [0.0.13]
   * Fixed access to categories recent, popular and exact show from kodi favourite list
 2020-09-10 [0.0.12]

--- a/mall.py
+++ b/mall.py
@@ -254,15 +254,25 @@ class MallApi():
 
         return count
 
+    def get_video_main_url(self, page):
+        # extracts a video url from a script tag, it's in an internal json structure under VideoSource value
+        script_tag = page.find(lambda tag: tag.name == 'script' and 'VideoSource' in tag.text)
+        # removes everything before the value of VideoSource including the quote character
+        tmp_str = re.sub(r'^.*VideoSource"[\s]*:[\s]*"', '', script_tag.string.encode('utf-8'))
+        # removes everything after the value including the quote character
+        return re.sub(r'["\s]*,["\s]*.*$', '', tmp_str).strip()
+
     def get_video_url(self, link, is_live=False):
         page = self.get_page(link)
 
         source = page.find('source')
 
         if not source:
-            main_link = page.find('meta', {'itemprop': 'image'})['content'].replace('retina.jpg', 'index.m3u8')
+            main_link = self.get_video_main_url(page)
         else:
-            main_link = source['src'] + '.m3u8'
+            main_link = source['src']
+
+        main_link += '.m3u8'
         url_parts = urlparse(main_link, 'https')
         main_link = urlunparse(url_parts)
 


### PR DESCRIPTION
The plugin has stopped working for live videos (version 0.0.13):
```
2020-10-22 18:02:50.145 T:1691345648 WARNING: [kodiswift] No converter provided, unicode should be used, but returning str value
2020-10-22 18:02:50.160 T:1691345648  NOTICE: [kodiswift] Request for "/livestream/%2Fvesmirne-starty%2Fstart-falcon-9-starlink-1-14-21-10" matches rule for function "livestream"
2020-10-22 18:02:51.257 T:1899875600   ERROR: Playlist Player: skipping unplayable item: 0, path [plugin://plugin.video.mall.tv/livestream/%2Fvesmirne-starty%2Fstart-falcon-9-starlink-1-14-21-10]
2020-10-22 18:02:51.277 T:1361036016 WARNING: CreateLoader - unsupported protocol(plugin) in plugin://plugin.video.mall.tv/livestream/%2Fmikyrova-uzasna-pout-internetem%2F900k-benny-vs-mikyr
2020-10-22 18:02:51.277 T:1361036016   ERROR: InputStream: Error opening, plugin://plugin.video.mall.tv/livestream/%2Fmikyrova-uzasna-pout-internetem%2F900k-benny-vs-mikyr
```
After investigation I've found out a live video url could not be extracted from `meta` tag any longer:
```xml
<meta itemprop=image content=https://d4110.gjirafa.com/api/media/malltv/tkq0tk/retina.jpg/>
```
The proper url is hidden in a javascript code block (see a snipped below):
```html
<script>var videoObject = JSON.parse(JSON.stringify({
    "ContentIds": {"video": [9123], "serie": [105], "channel": [37]},
    "VideoId": 9123,
    "EntityId": 66230,
    "SerieEntityId": 3774,
    "EntityName": "ykzxyx",
    "Title": "Vyhraj robotický vysavač! Vyhraj to s Viledou (26. 10. v 19:00) ",
    "Description": "\u003cp\u003eV ponděl\u0026iacute; \u003cstrong\u003e26. 10. od 19 hodin\u003c/strong\u003e hrajeme \u003cstrong\u003eVyhraj to! s Viledou\u003c/strong\u003e o tyto b\u0026aacute;ječn\u0026eacute; ceny:\u003c/p\u003e\r\n\r\n\u003cp\u003e1. m\u0026iacute;sto \u003ca href=\"https://www.mall.cz/vysavace/vileda-vr201-petpro?utm_source=mall.tv\u0026amp;utm_medium=detail_poradu\u0026amp;utm_campaign=vyhraj_to\u0026amp;utm_term=1_vileda_vr201_petpro\u0026amp;utm_content=26_10_2020\" target=\"_blank\"\u003eVileda robotick\u0026yacute; vysavač VR201 PetPro\u003c/a\u003e\u003c/p\u003e\r\n\r\n\u003cp\u003e2. m\u0026iacute;sto \u003ca href=\"https://www.mall.cz/vysavace/vileda-steam-mop-xxl-1347505?utm_source=mall.tv\u0026amp;utm_medium=detail_poradu\u0026amp;utm_campaign=vyhraj_to\u0026amp;utm_term=2_vileda_steam_mop_xxl\u0026amp;utm_content=26_10_2020\" target=\"_blank\"\u003eVileda Steam Mop XXL\u003c/a\u003e\u003c/p\u003e\r\n\r\n\u003cp\u003e3. m\u0026iacute;sto \u003ca href=\"https://www.mall.cz/zehlicky-prislusenstvi/vileda-total-reflect-plus-zehlici-prkno-130-x-44-cm?utm_source=mall.tv\u0026amp;utm_medium=detail_poradu\u0026amp;utm_campaign=vyhraj_to\u0026amp;utm_term=3_vileda_total_reflect_plus\u0026amp;utm_content=26_10_2020\" target=\"_blank\"\u003eVileda žehl\u0026iacute;c\u0026iacute; prknoTotal Reflex Plus\u003c/a\u003e\u003c/p\u003e\r\n\r\n\u003cp\u003e4. m\u0026iacute;sto \u003ca href=\"https://www.mall.cz/susaky-pradlo/vileda-susak-na-pradlo-infinity-27-m?utm_source=mall.tv\u0026amp;utm_medium=detail_poradu\u0026amp;utm_campaign=vyhraj_to\u0026amp;utm_term=4_vileda_susak_na_pradlo_infinity\u0026amp;utm_content=26_10_2020\" target=\"_blank\"\u003eVileda su\u0026scaron;\u0026aacute;k na pr\u0026aacute;dlo Infinity\u003c/a\u003e\u003c/p\u003e\r\n\r\n\u003cp\u003e5. m\u0026iacute;sto \u003ca href=\"https://www.mall.cz/sety-mopy/vileda-spray-max-mop-box-12?utm_source=mall.tv\u0026amp;utm_medium=detail_poradu\u0026amp;utm_campaign=vyhraj_to\u0026amp;utm_term=5_vileda_spray_max_mop_box\u0026amp;utm_content=26_10_2020\" target=\"_blank\"\u003eVileda Spray Mop Box\u003c/a\u003e\u003c/p\u003e\r\n",
    "VideoSource": "https://d4110.gjirafa.com/live/rcBFeREIqcMkNthqI6YCr3Riss97l2MC/tkq0tk",
    "ThumbnailUrl": "https://d4110.gjirafa.com/api/media/malltv/tkq0tk/retina.jpg",
    "EmbedUrl": "/embed/live-video-26-10-2020-19-00",
    "Duration": "00:00",
    "DurationSeconds": 0,
    "React": 3,
    "EntityCounts": {
        "EntityId": 66230,
        "Subscribed": false,
        "Likes": {"Enabled": true, "Show": true, "Count": 7, "StrCount": "7"},
        "Dislikes": {"Enabled": true, "Show": true, "Count": 0, "StrCount": "0"},
        "Comments": {"Enabled": true, "Show": true, "Count": 8, "StrCount": "8"},
        "Displays": {"Enabled": false, "Show": false, "Count": 2029, "StrCount": "2,029"},
        "Views": {"Enabled": false, "Show": false, "Count": 669, "StrCount": "669 zhlédnutí"},
        "Subscribers": {"Enabled": false, "Show": false, "Count": 0, "StrCount": null}
    },
```
This works also for other videos, not only for live streams.

The fix is just a proposal, I'm not familiar with Kodi plugins, the code is rather meant as a hot fix from my side. Feel free to come up with a better solution.