### PR TITLE
Live stream categories introduced

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -33,7 +33,7 @@ def video(link):
 
 @plugin.route('/livestream/<link>')
 def livestream(link):
-    url = api.get_video_url(link, True)
+    url = api.get_video_url(link)
     if url:
         plugin.set_resolved_url(url)
 
@@ -54,9 +54,13 @@ def paged_videos(video_type, page='0'):
 
     return items
 
-@plugin.route('/live', name='live',  options={'video_type': 'live'})
-def live(video_type):
-    items = api.get_live(video_type)
+@plugin.route('/live')
+def live_index():
+    return api.get_live_categories()
+
+@plugin.route('/live/<category_id>')
+def live(category_id):
+    items = api.get_live_category_videos(category_id)
 
     plugin.set_content('episodes')
 
@@ -82,7 +86,7 @@ def index():
     }
     live = {
         'label': plugin.get_string(30019),
-        'path': plugin.url_for('live')
+        'path': plugin.url_for(live_index)
     }
     return [show, category, recent, popular, live]
 

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.mall.tv"
        name="Mall.TV"
-       version="0.0.14"
+       version="0.0.15"
        provider-name="koudi">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+2020-11-09 [0.0.15]
+  * Added sub-categories for live streams
 2020-10-29 [0.0.14]
   * Fixed live video stream playback
 2020-10-14 [0.0.13]

--- a/mall.py
+++ b/mall.py
@@ -298,13 +298,18 @@ class MallApi():
             self.plugin.notify(self.plugin.get_string(30021).encode("utf-8"), delay=7000, image=self.plugin._addon.getAddonInfo('icon'))
             return None
 
+        # non "index.m3u8" playlists contains video-id together with quality id
+        video_id=''
+        if not main_link.endswith('index'):
+            video_id=main_link.split('/')[-1]
+
         main_link += '.m3u8'
         url_parts = urlparse(main_link, 'https')
         main_link = urlunparse(url_parts)
 
         index_list = requests.get(main_link).text
 
-        qualities = re.findall(r'(\d+)/index.m3u8', index_list, flags=re.MULTILINE)
+        qualities = re.findall(video_id+r'(\d+)/index.m3u8', index_list, flags=re.MULTILINE)
         if not len(qualities):
             self.plugin.notify(self.plugin.get_string(30021).encode("utf-8"), delay=7000, image=self.plugin._addon.getAddonInfo('icon'))
             return None

--- a/mall.py
+++ b/mall.py
@@ -141,8 +141,14 @@ class MallApi():
         page = self.get_page(('/zive' if self.is_cz else '/nazivo'))
         video_grids = page.find_all('section', {'class': ['video-grid', 'isVideo']})
 
-        result = []
-        for category_id, grid in enumerate(video_grids):
+        if not video_grids:
+            return []
+
+        # display current streams directly in the root as first items
+        result = self.get_live_category_videos(0, page)
+
+        # then the rest of the categories
+        for category_id, grid in enumerate(video_grids[1:], 1):
             live_section_title = grid.find('h2', {'class': ['video-grid__title']}).text
             result.append({
                 'label': live_section_title,
@@ -151,8 +157,9 @@ class MallApi():
 
         return result
 
-    def get_live_category_videos(self, category):
-        page = self.get_page(('/zive' if self.is_cz else '/nazivo'))
+    def get_live_category_videos(self, category, page=None):
+        if not page:
+            page = self.get_page(('/zive' if self.is_cz else '/nazivo'))
 
         videos = self.extract_live(page, category)
 


### PR DESCRIPTION
Introducing sub-categories for live streams. In the current version (0.0.14) only active live streams are displayed (the first section).

The change description:
* another level in videos hierarchy under the live section added
* all sections (categories) of live streams are parsed from an html page and divided into categories - categories are dynamic, currently the following are present on mall.tv:
  * current
  * non-stop
  * future
  * passed
* current live streams are displayed directly in the root level, not in a separate section
* live streams from the past are treated as normal videos
* future live streams are not playable, a warning is displayed instead (30021)


 